### PR TITLE
feat(#8): core-network API 키 & Retrofit 클라이언트 구성

### DIFF
--- a/core/core-network/build.gradle.kts
+++ b/core/core-network/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 val localProperties = Properties().apply {
     val file = rootProject.file("local.properties")
-    if (file.exists()) load(file.inputStream())
+    if (file.exists()) file.inputStream().use { load(it) }
 }
 
 android {
@@ -24,8 +24,13 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
 
-        buildConfigField("String", "FOOTBALL_BASE_URL", "\"${localProperties["FOOTBALL_BASE_URL"]}\"")
-        buildConfigField("String", "FOOTBALL_API_KEY", "\"${localProperties["FOOTBALL_API_KEY"]}\"")
+        val footballBaseUrl = localProperties["FOOTBALL_BASE_URL"]?.toString()
+            ?: throw GradleException("local.properties에 FOOTBALL_BASE_URL을 추가해주세요")
+        val footballApiKey = localProperties["FOOTBALL_API_KEY"]?.toString()
+            ?: throw GradleException("local.properties에 FOOTBALL_API_KEY를 추가해주세요")
+
+        buildConfigField("String", "FOOTBALL_BASE_URL", "\"$footballBaseUrl\"")
+        buildConfigField("String", "FOOTBALL_API_KEY", "\"$footballApiKey\"")
     }
 
     buildFeatures {

--- a/core/core-network/build.gradle.kts
+++ b/core/core-network/build.gradle.kts
@@ -1,7 +1,14 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+}
+
+val localProperties = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) load(file.inputStream())
 }
 
 android {
@@ -16,6 +23,13 @@ android {
         minSdk = 28
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+
+        buildConfigField("String", "FOOTBALL_BASE_URL", "\"${localProperties["FOOTBALL_BASE_URL"]}\"")
+        buildConfigField("String", "FOOTBALL_API_KEY", "\"${localProperties["FOOTBALL_API_KEY"]}\"")
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     buildTypes {

--- a/core/core-network/src/main/java/com/soma2026/lab/core/network/ApiKeyInterceptor.kt
+++ b/core/core-network/src/main/java/com/soma2026/lab/core/network/ApiKeyInterceptor.kt
@@ -6,7 +6,7 @@ import okhttp3.Response
 internal class ApiKeyInterceptor(private val apiKey: String) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()
-            .addHeader("X-Auth-Token", apiKey)
+            .header("X-Auth-Token", apiKey)
             .build()
         return chain.proceed(request)
     }

--- a/core/core-network/src/main/java/com/soma2026/lab/core/network/ApiKeyInterceptor.kt
+++ b/core/core-network/src/main/java/com/soma2026/lab/core/network/ApiKeyInterceptor.kt
@@ -1,0 +1,13 @@
+package com.soma2026.lab.core.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+internal class ApiKeyInterceptor(private val apiKey: String) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .addHeader("X-Auth-Token", apiKey)
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/core/core-network/src/main/java/com/soma2026/lab/core/network/NetworkModule.kt
+++ b/core/core-network/src/main/java/com/soma2026/lab/core/network/NetworkModule.kt
@@ -27,7 +27,8 @@ object NetworkModule {
             .addInterceptor(ApiKeyInterceptor(BuildConfig.FOOTBALL_API_KEY))
             .addInterceptor(
                 HttpLoggingInterceptor().apply {
-                    level = HttpLoggingInterceptor.Level.BODY
+                    level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                            else HttpLoggingInterceptor.Level.NONE
                 }
             )
             .build()

--- a/core/core-network/src/main/java/com/soma2026/lab/core/network/NetworkModule.kt
+++ b/core/core-network/src/main/java/com/soma2026/lab/core/network/NetworkModule.kt
@@ -24,6 +24,7 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(): OkHttpClient =
         OkHttpClient.Builder()
+            .addInterceptor(ApiKeyInterceptor(BuildConfig.FOOTBALL_API_KEY))
             .addInterceptor(
                 HttpLoggingInterceptor().apply {
                     level = HttpLoggingInterceptor.Level.BODY
@@ -38,7 +39,7 @@ object NetworkModule {
         gson: Gson,
     ): Retrofit =
         Retrofit.Builder()
-            .baseUrl("https://api.example.com/")
+            .baseUrl(BuildConfig.FOOTBALL_BASE_URL)
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()


### PR DESCRIPTION
## 📄 관련 이슈

Closes #8

## 📝 변경 내용

`local.properties`의 API 키를 `BuildConfig`로 노출하고, `core-network` 모듈에 football-data.org API 호출을 위한 Retrofit 클라이언트를 구성했다.

## 🔧 작업 상세

### `core-network/build.gradle.kts`
- `local.properties`에서 `FOOTBALL_BASE_URL`, `FOOTBALL_API_KEY` 읽기
- `BuildConfig` 필드로 노출 (`buildFeatures.buildConfig = true`)

### `ApiKeyInterceptor`
- 모든 요청 헤더에 `X-Auth-Token` 자동 주입
- `internal`로 선언해 모듈 외부 노출 차단

### `NetworkModule`
- `baseUrl` 하드코딩 → `BuildConfig.FOOTBALL_BASE_URL` 참조
- `ApiKeyInterceptor` 추가 (LoggingInterceptor보다 앞에 배치)

## ✅ 체크리스트

- [x] `local.properties` → `BuildConfig` 연동
- [x] `ApiKeyInterceptor` 작성
- [x] `NetworkModule` baseUrl·Interceptor 적용
- [x] `core-network` 빌드 확인