### PR TITLE
feat(#12): core-ui 공통 Compose 컴포넌트 및 테마 구성

### DIFF
--- a/core/core-ui/build.gradle.kts
+++ b/core/core-ui/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-    api(libs.coil.compose)
+    implementation(libs.coil.compose)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/core/core-ui/build.gradle.kts
+++ b/core/core-ui/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 
+    api(libs.coil.compose)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/FormBadge.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/FormBadge.kt
@@ -1,0 +1,57 @@
+package com.soma2026.lab.core.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.soma2026.lab.core.ui.theme.FormDraw
+import com.soma2026.lab.core.ui.theme.FormLoss
+import com.soma2026.lab.core.ui.theme.FormWin
+
+@Composable
+fun FormBadge(
+    form: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        form.split(",").takeLast(5).forEach { result ->
+            FormDot(result.trim())
+        }
+    }
+}
+
+@Composable
+private fun FormDot(result: String) {
+    val color = when (result) {
+        "W" -> FormWin
+        "D" -> FormDraw
+        "L" -> FormLoss
+        else -> Color.Gray
+    }
+    Box(
+        modifier = Modifier
+            .size(16.dp)
+            .background(color = color, shape = CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = result,
+            color = Color.White,
+            fontSize = 8.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/FormBadge.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/FormBadge.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,11 +24,12 @@ fun FormBadge(
     form: String,
     modifier: Modifier = Modifier
 ) {
+    val results = remember(form) { form.split(",").takeLast(5) }
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
-        form.split(",").takeLast(5).forEach { result ->
+        results.forEach { result ->
             FormDot(result.trim())
         }
     }

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/StandingRow.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/StandingRow.kt
@@ -1,0 +1,85 @@
+package com.soma2026.lab.core.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun StandingRow(
+    position: Int,
+    teamName: String,
+    teamLogoUrl: String,
+    playedGames: Int,
+    won: Int,
+    drawn: Int,
+    lost: Int,
+    points: Int,
+    goalDifference: Int,
+    form: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = position.toString(),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.width(20.dp)
+        )
+        TeamLogo(
+            url = teamLogoUrl,
+            contentDescription = teamName,
+            size = 24.dp
+        )
+        Text(
+            text = teamName,
+            fontSize = 13.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+        StatText(playedGames.toString())
+        StatText(won.toString())
+        StatText(drawn.toString())
+        StatText(lost.toString())
+        StatText(
+            text = if (goalDifference > 0) "+$goalDifference" else goalDifference.toString()
+        )
+        StatText(
+            text = points.toString(),
+            fontWeight = FontWeight.Bold
+        )
+        FormBadge(form = form)
+    }
+}
+
+@Composable
+private fun StatText(
+    text: String,
+    fontWeight: FontWeight = FontWeight.Normal
+) {
+    Text(
+        text = text,
+        fontSize = 12.sp,
+        fontWeight = fontWeight,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.width(24.dp)
+    )
+}

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/TeamLogo.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/component/TeamLogo.kt
@@ -1,0 +1,22 @@
+package com.soma2026.lab.core.ui.component
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+
+@Composable
+fun TeamLogo(
+    url: String,
+    contentDescription: String,
+    size: Dp = 32.dp,
+    modifier: Modifier = Modifier
+) {
+    AsyncImage(
+        model = url,
+        contentDescription = contentDescription,
+        modifier = modifier.size(size)
+    )
+}

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Color.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Color.kt
@@ -1,0 +1,15 @@
+package com.soma2026.lab.core.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple80 = Color(0xFFD0BCFF)
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+
+val Purple40 = Color(0xFF6650A4)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)
+
+val FormWin = Color(0xFF00C853)
+val FormDraw = Color(0xFFFFAB00)
+val FormLoss = Color(0xFFD50000)

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Theme.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Theme.kt
@@ -1,0 +1,45 @@
+package com.soma2026.lab.core.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple80,
+    secondary = PurpleGrey80,
+    tertiary = Pink80
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40
+)
+
+@Composable
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Theme.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Theme.kt
@@ -39,7 +39,7 @@ fun AppTheme(
 
     MaterialTheme(
         colorScheme = colorScheme,
-        typography = Typography,
+        typography = AppTypography,
         content = content
     )
 }

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Typography.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Typography.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-val Typography = Typography(
+val AppTypography = Typography(
     bodyLarge = TextStyle(
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,

--- a/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Typography.kt
+++ b/core/core-ui/src/main/java/com/soma2026/lab/core/ui/theme/Typography.kt
@@ -1,0 +1,27 @@
+package com.soma2026.lab.core.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Typography = Typography(
+    bodyLarge = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    ),
+    bodyMedium = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    labelSmall = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ okhttp = "4.11.0"
 gson = "2.10.1"
 hilt = "2.59.2"
 ksp = "2.2.10-2.0.2"
+coil = "2.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +42,7 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version = "1" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
## 📄 관련 이슈

Closes #12

## 📝 변경 내용

두 아키텍처(`layered-presentation`, `clean-presentation`)가 공유하는 Compose 테마와 순위표 화면용 공통 컴포넌트를 `core-ui` 모듈에 구성했다.

## 🔧 작업 상세

### 의존성
- Coil 2.7.0 버전 카탈로그 추가 및 `core-ui`에 `api` 의존성 적용

### Theme
- `Color.kt` — 기본 컬러 팔레트 + Form 결과별 색상 (Win/Draw/Loss)
- `Typography.kt` — 순위표에 사용할 텍스트 스타일 정의
- `Theme.kt` — `AppTheme` (다이나믹 컬러 지원, 다크모드 대응)

### Components
- `TeamLogo` — Coil `AsyncImage` 기반 팀 로고 컴포넌트
- `FormBadge` — 최근 5경기 W/D/L 도트 뱃지 컴포넌트
- `StandingRow` — 순위·팀명·로고·승무패·승점·골득실·최근성적을 한 줄로 표시하는 컴포넌트

## ✅ 체크리스트

- [x] Coil 의존성 추가
- [x] Theme / Color / Typography 구성
- [x] TeamLogo 컴포넌트
- [x] FormBadge 컴포넌트
- [x] StandingRow 컴포넌트
- [x] core-ui 빌드 확인