### PR TITLE
test(#20): clean-domain UseCase Fake 단위 테스트 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,10 @@ app-layered / app-clean
 - ViewModel은 `@HiltViewModel`로 주입
 - UseCase는 Repository 구현체(`RepositoryImpl`)를 직접 주입받아 사용
 - 테스트 시 MockK로 구현체를 모킹 (인터페이스 추출 없음)
+- `layered-domain`은 `android.library` 플러그인 사용 — `layered-data`(Android 모듈)에 의존하기 때문이며, Android API를 직접 사용하지는 않음. Clean과의 의도적인 차이점.
 
 ### Clean 아키텍처 (`clean-*`)
-- `clean-domain`은 **순수 Kotlin 모듈** — Android 의존성 없음
+- `clean-domain`은 **순수 Kotlin 모듈** (`kotlin.jvm`) — data 레이어를 모르므로 Android 오염 없음
 - Entity는 domain에만 존재하며 data 레이어에서는 DTO + Mapper로 변환
 - UseCase는 단일 책임: 파일 하나에 `operator fun invoke()` 하나
 - `@Binds`를 사용한 인터페이스 바인딩 방식으로 DI

--- a/clean/clean-domain/build.gradle.kts
+++ b/clean/clean-domain/build.gradle.kts
@@ -6,4 +6,5 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.javax.inject)  // JSR-330: @Inject, @Singleton (DI 프레임워크 무관)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/fake/FakeSampleRepository.kt
+++ b/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/fake/FakeSampleRepository.kt
@@ -1,0 +1,10 @@
+package com.soma2026.lab.clean.domain.fake
+
+import com.soma2026.lab.clean.domain.repository.SampleRepository
+
+class FakeSampleRepository : SampleRepository {
+
+    var result: Result<String> = Result.success("Hello from Fake")
+
+    override suspend fun getData(): Result<String> = result
+}

--- a/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/fake/FakeStandingsRepository.kt
+++ b/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/fake/FakeStandingsRepository.kt
@@ -1,0 +1,11 @@
+package com.soma2026.lab.clean.domain.fake
+
+import com.soma2026.lab.clean.domain.model.Standing
+import com.soma2026.lab.clean.domain.repository.StandingsRepository
+
+class FakeStandingsRepository : StandingsRepository {
+
+    var result: Result<List<Standing>> = Result.success(emptyList())
+
+    override suspend fun getStandings(): Result<List<Standing>> = result
+}

--- a/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/usecase/GetSampleDataUseCaseTest.kt
+++ b/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/usecase/GetSampleDataUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.soma2026.lab.clean.domain.usecase
+
+import com.soma2026.lab.clean.domain.fake.FakeSampleRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetSampleDataUseCaseTest {
+
+    private lateinit var fakeRepository: FakeSampleRepository
+    private lateinit var useCase: GetSampleDataUseCase
+
+    @Before
+    fun setUp() {
+        fakeRepository = FakeSampleRepository()
+        useCase = GetSampleDataUseCase(fakeRepository)
+    }
+
+    @Test
+    fun `성공 응답을 받으면 Result_success를 반환한다`() = runTest {
+        fakeRepository.result = Result.success("Hello from Fake")
+
+        val result = useCase()
+
+        assertTrue(result.isSuccess)
+        assertEquals("Hello from Fake", result.getOrNull())
+    }
+
+    @Test
+    fun `실패 응답을 받으면 Result_failure를 반환한다`() = runTest {
+        val exception = RuntimeException("Data error")
+        fakeRepository.result = Result.failure(exception)
+
+        val result = useCase()
+
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}

--- a/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/usecase/GetStandingsUseCaseTest.kt
+++ b/clean/clean-domain/src/test/kotlin/com/soma2026/lab/clean/domain/usecase/GetStandingsUseCaseTest.kt
@@ -1,0 +1,69 @@
+package com.soma2026.lab.clean.domain.usecase
+
+import com.soma2026.lab.clean.domain.fake.FakeStandingsRepository
+import com.soma2026.lab.clean.domain.model.Standing
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetStandingsUseCaseTest {
+
+    private lateinit var fakeRepository: FakeStandingsRepository
+    private lateinit var useCase: GetStandingsUseCase
+
+    @Before
+    fun setUp() {
+        fakeRepository = FakeStandingsRepository()
+        useCase = GetStandingsUseCase(fakeRepository)
+    }
+
+    @Test
+    fun `성공 응답을 받으면 Result_success를 반환한다`() = runTest {
+        // Clean 아키텍처 특징: domain은 DTO를 모른다.
+        // Repository가 이미 도메인 모델로 변환해서 반환하므로 UseCase는 순수하게 전달만 한다.
+        // DTO 매핑 검증은 clean-data 레이어의 Mapper 테스트에서 담당한다.
+        val standings = listOf(
+            Standing(
+                position = 1,
+                teamName = "Arsenal",
+                teamLogoUrl = "https://example.com/arsenal.png",
+                playedGames = 30,
+                won = 20,
+                drawn = 5,
+                lost = 5,
+                points = 65,
+                goalDifference = 30,
+                form = "WWWDW"
+            )
+        )
+        fakeRepository.result = Result.success(standings)
+
+        val result = useCase()
+
+        assertTrue(result.isSuccess)
+        assertEquals(standings, result.getOrNull())
+    }
+
+    @Test
+    fun `빈 리스트를 받으면 빈 Result_success를 반환한다`() = runTest {
+        fakeRepository.result = Result.success(emptyList())
+
+        val result = useCase()
+
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<Standing>(), result.getOrNull())
+    }
+
+    @Test
+    fun `실패 응답을 받으면 Result_failure를 반환한다`() = runTest {
+        val exception = RuntimeException("Network error")
+        fakeRepository.result = Result.failure(exception)
+
+        val result = useCase()
+
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}


### PR DESCRIPTION
## Summary

- `clean-domain` UseCase 단위 테스트 작성 (이슈 #20)
- Fake Repository 방식 채택 — domain에 인터페이스가 있으므로 MockK 불필요
- 순수 Kotlin 모듈이라 Android 의존성 없이 JVM 테스트로 실행

## Layered vs Clean 테스트 방식 비교

| | Layered (#19) | Clean (#20) |
|---|---|---|
| 테스트 대역 | MockK (구현체 모킹) | Fake (인터페이스 구현) |
| DTO 의존성 | domain 테스트에 DTO 등장 | domain 테스트에 DTO 없음 |
| 매핑 검증 위치 | domain UseCase 테스트 | clean-data Mapper 테스트 |

## 변경 사항

- `GetStandingsUseCaseTest`: 성공 / 빈 리스트 / 실패 3가지 케이스
- `GetSampleDataUseCaseTest`: 성공 / 실패 2가지 케이스
- `FakeStandingsRepository`, `FakeSampleRepository` 추가
- `kotlinx-coroutines-test` 의존성 추가

## Test plan

- [x] `./gradlew :clean:clean-domain:test` 통과 확인

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)